### PR TITLE
Add limit to CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What does Candelabra do?
 
-Candelabra is a web crawler designed to generate a thorough sitemap and audit each page for valid, semantic HTML and accessibility violations. Using Candelabra, you can check any website for accessibility violations. More importantly, you can point it to local servers and other developer environments to test your code before you deploy.
+Candelabra is a web crawler designed to generate a sitemap from an entry URL and audit each of its pages for semantic HTML and accessibility violations. Using Candelabra, you can check any website for accessibility violations. More importantly, you can point it to local servers and other developer environments to test your code before you deploy.
 
 It works out of the box for any website that doesn't require authentication on entry. This means it can audit any JavaScript-rendered website including those built with the popular front-end frameworks: React, Vue, Ember, Angular, etc.
 
@@ -29,6 +29,7 @@ candelabra <entry-url>
 | -V, --version         | output the version number                               |
 | -o, --output <path>   | file path to output JSON, defaults to displaying inline |
 | -g, --groupBy <group> | SEVERITY / PAGE / RULE, defaults to SEVERITY            |
+| -l, --limit <limit>   | limit the number of URLs to crawl, defaults to 1000     |
 | -h, --help            | output usage information                                |
 
 Use `candelabra -h` for a current list of options while development continues.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "axe-core": "^3.3.2",
     "axe-puppeteer": "^1.0.0",
     "colors": "^1.3.3",
-    "commander": "^3.0.0",
+    "commander": "^6.1.0",
     "core-js": "^3.2.1",
     "lodash": "^4.17.15",
     "puppeteer": "^1.19.0",

--- a/src/checkWebsiteForViolations.ts
+++ b/src/checkWebsiteForViolations.ts
@@ -43,12 +43,21 @@ export default async (url: Url, options: CommandOptions): Promise<void> => {
 
   let queue: Url[] = [];
   let totalViolations: Violation[] = [];
+  let count: number = 0;
 
   const recursivelyCheckForViolations = async (url: Url): Promise<void> => {
     const checkedUrls = Object.keys(sitemap);
 
-    if (!checkedUrls.includes(url)) {
-      updateStatusMessage(url, entryUrl, queue, totalViolations);
+    if (
+      !checkedUrls.includes(url) &&
+      !(options.limit && count >= options.limit)
+    ) {
+      updateStatusMessage(
+        url,
+        entryUrl,
+        options.limit ? Math.min(queue.length, options.limit) : queue.length,
+        totalViolations
+      );
 
       await page.setViewport({ width: 1366, height: 768 });
       await page.setBypassCSP(true);
@@ -118,7 +127,10 @@ export default async (url: Url, options: CommandOptions): Promise<void> => {
           []
         );
 
-      if (queue.length) await recursivelyCheckForViolations(queue[0]);
+      if (queue.length) {
+        count = count + 1;
+        await recursivelyCheckForViolations(queue[0]);
+      }
     }
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,12 +20,17 @@ candelabra
     '-g, --groupBy <group>',
     'SEVERITY | PAGE | TYPE, defaults to SEVERITY'
   )
+  .option(
+    '-l, --limit <group>',
+    'limit the number of URLs to crawl, defaults to 1000'
+  )
   .command('* <url>')
   .action((url: Url): void => {
     const commanderOptions: any = candelabra.opts();
     const options: CommandOptions = {
       output: commanderOptions.output,
-      groupBy: commanderOptions.groupBy
+      groupBy: commanderOptions.groupBy,
+      limit: commanderOptions.limit || 1000
     };
 
     checkWebsiteForViolations(url, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export type AxeRule =
 export interface CommandOptions {
   output: Filepath | null;
   groupBy: OutputGroupBy | null;
+  limit: number | null;
 }
 
 export type Filepath = string;

--- a/src/updateStatusMessage.ts
+++ b/src/updateStatusMessage.ts
@@ -5,7 +5,7 @@ import { Url } from './types';
 export default (
   url: Url,
   entryUrl: Url,
-  queue: Url[],
+  remaining: number,
   totalViolations: NodeResult[]
 ): void => {
   // @ts-ignore - see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31505
@@ -20,7 +20,7 @@ export default (
   );
   process.stdout.write(
     `${`${totalViolations.length}`.red.bold} violations found so far. ${
-      `There are ${`${queue.length}`.bold} remaining pages in the queue.`.gray
+      `There are ${`${remaining}`.bold} remaining pages in the queue.`.gray
     }`
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,13 +1043,13 @@ colors@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
 
-commander@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
-
 commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+
+commander@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
 
 component-emitter@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
This allows you to add a limit to how many pages are crawled in a single process. This will be useful for users to quickly sample the main pages of their site. It will also enable users to set limits in CI environments where Candelabra is used in integration workflows.